### PR TITLE
examples: Correct allocation of StatResult

### DIFF
--- a/examples.c
+++ b/examples.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     stat_object_add(ctr, difference);
   }
   /* How to print the statistics collected */
-  StatResult r = (StatResult)malloc(sizeof(StatResult));
+  StatResult r = (StatResult)malloc(sizeof(sStatResult));
   stat_obj_value(ctr,r);
   printf("time to yield: avg: %10.4f min: %10.4f max: %10.4f stddev: %10.4f\n",
          r->mean, r->min, r->max, r->stddev);


### PR DESCRIPTION
The type StatResult defined as a pointer to a stat_obj_struct structure
(sStatObject is also defined as this structure). When memory is
allocated for r in main(), the size of StatResult is erroneously used
instead of the size of sStatResult. This results in a heap buffer
overflow when stat_obj_value() is called, as it expects r to be a
pointer to a stat_obj_struct structure.